### PR TITLE
Fix annotationCol in correlation heatmap

### DIFF
--- a/R/methods-plotCorrelationHeatmap.R
+++ b/R/methods-plotCorrelationHeatmap.R
@@ -69,7 +69,7 @@ NULL
             column_to_rownames
         # Define colors for each annotation column
         annotationColors <- lapply(
-            seq_along(dim(annotationCol)[[2L]]), function(a) {
+            seq_len(dim(annotationCol)[[2L]]), function(a) {
                 col <- annotationCol[[a]] %>%
                     levels
                 colors <- annotationCol[[a]] %>%

--- a/R/methods-plotCorrelationHeatmap.R
+++ b/R/methods-plotCorrelationHeatmap.R
@@ -69,7 +69,7 @@ NULL
             column_to_rownames
         # Define colors for each annotation column
         annotationColors <- lapply(
-            seq_len(dim(annotationCol)[[2L]]), function(a) {
+            seq_along(colnames(annotationCol)), function(a) {
                 col <- annotationCol[[a]] %>%
                     levels
                 colors <- annotationCol[[a]] %>%


### PR DESCRIPTION
The code was working only if one variable is in interestingGroups. `seq_along` gives always one value instead of a consecutive serie from 1 to ncols. I changed for `seq_len` that gives the expected value:

```
R> seq_along(2)
[1] 1
R> seq_len(2)
[1] 1 2
```