### PR TITLE
Fix subset method for each object name.

### DIFF
--- a/R/methods-subset.R
+++ b/R/methods-subset.R
@@ -171,6 +171,8 @@ NULL
 
 }
 
+
+
 # Methods ====
 #' @rdname subset
 #' @export
@@ -183,7 +185,8 @@ setMethod(
         .subset(x, i, j, ..., drop)
     })
 
-# Methods ====
+
+
 #' @rdname subset
 #' @export
 setMethod(


### PR DESCRIPTION
subset method wasn't working with any of the object, it seems the definition of the object family doesn't work with `[]` method. I created two methods, one for each object until we removed completely the old one.