### PR TITLE
Documentation fix for `resultsTables()`

### DIFF
--- a/R/methods-resultsTables.R
+++ b/R/methods-resultsTables.R
@@ -103,7 +103,7 @@ NULL
     summary = TRUE,
     headerLevel = 3,
     write = FALSE,
-    dir = file.path("results", "differential_expression"),
+    dir = getwd(),
     quiet = FALSE) {
     contrast <- .resContrastName(object)
     fileStem <- snake(contrast)

--- a/R/methods-resultsTables.R
+++ b/R/methods-resultsTables.R
@@ -41,7 +41,8 @@
 #'     res,
 #'     lfc = 0.25,
 #'     annotable = annotable,
-#'     summary = FALSE,
+#'     summary = TRUE,
+#'     headerLevel = 2,
 #'     write = FALSE)
 #' names(resTbl)
 NULL
@@ -101,7 +102,7 @@ NULL
     lfc = 0,
     annotable = TRUE,
     summary = TRUE,
-    headerLevel = 3,
+    headerLevel = 2,
     write = FALSE,
     dir = getwd(),
     quiet = FALSE) {

--- a/man/resultsTables.Rd
+++ b/man/resultsTables.Rd
@@ -10,7 +10,7 @@
 resultsTables(object, ...)
 
 \S4method{resultsTables}{DESeqResults}(object, lfc = 0, annotable = TRUE,
-  summary = TRUE, headerLevel = 3, write = FALSE, dir = getwd(),
+  summary = TRUE, headerLevel = 2, write = FALSE, dir = getwd(),
   quiet = FALSE)
 }
 \arguments{
@@ -63,7 +63,8 @@ resTbl <- resultsTables(
     res,
     lfc = 0.25,
     annotable = annotable,
-    summary = FALSE,
+    summary = TRUE,
+    headerLevel = 2,
     write = FALSE)
 names(resTbl)
 }

--- a/man/resultsTables.Rd
+++ b/man/resultsTables.Rd
@@ -10,8 +10,8 @@
 resultsTables(object, ...)
 
 \S4method{resultsTables}{DESeqResults}(object, lfc = 0, annotable = TRUE,
-  summary = TRUE, headerLevel = 3, write = FALSE,
-  dir = file.path("results", "differential_expression"), quiet = FALSE)
+  summary = TRUE, headerLevel = 3, write = FALSE, dir = getwd(),
+  quiet = FALSE)
 }
 \arguments{
 \item{object}{Object.}


### PR DESCRIPTION
The `resultsTables()` documentation didn't get updated correctly in the `man/` directory, so the `headerLevel` argument errored in the DE template. I tweaked the parameters slightly, setting the default header level to 2, instead of 3, which is standard for R Markdown. Additionally, the function now writes the files to the current working directory rather than a nested subdirectory, by default (similar behavior in v0.1.5 code on develop branch).