### PR TITLE
Add biotype and broadclass violin plots.

### DIFF
--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -147,7 +147,7 @@ plotCountsPerGene(bcb, normalized = "tmm")
 ```
 
 ```{r biotype_plot, eval="geneBiotype" %in% colnames(rowData(bcb)), echo=FALSE, results='asis'}
-cat("## TPM per biotype\n")
+basejump::mdHeader("TPM per biotype", level=2)
 cat("Different RNA-seq processing methods can preferentially capture a subset of the RNA species
 from the total RNA. For example, polyA selection should select for mostly coding genes and
 skip a large percentage of non-polyA non-coding RNA. Here we make boxplots of the TPM for
@@ -180,7 +180,7 @@ ggplot(biotypetpm, aes(sample, tpm))+
 ```
 
 ```{r broadclass_plot, eval="broadClass" %in% colnames(rowData(bcb)), echo=FALSE, results='asis'}
-cat("## TPM per broad biotype class\n")
+basejump::mdHeader("TPM per broad biotype class", level=2)
 cat("The Ensembl biotype clasifications are too specific to plot them all-- here we have grouped
 the biotypes into broad classes and plot boxplots of the TPM for each sample.")
 biotypetpm = tpm(bcb) %>%

--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -188,7 +188,8 @@ biotypetpm = tpm(bcb) %>%
   tibble::rownames_to_column("gene") %>%
   tidyr::gather(sample, tpm, -gene) %>%
   dplyr::left_join(rowData(bcb) %>%
-                   as.data.frame(), by=c("gene"="geneID"))
+                   as.data.frame(), by=c("gene"="geneID")) %>%
+  filter(!is.na(broadClass))
 
 ggplot(biotypetpm, aes(sample, tpm)) +
   geom_violin() +

--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -191,8 +191,8 @@ biotypetpm = tpm(bcb) %>%
                    as.data.frame(), by=c("gene"="geneID"))
 
 ggplot(biotypetpm, aes(sample, tpm)) +
-  geom_boxplot() +
-  facet_wrap(~geneBiotype) +
+  geom_violin() +
+  facet_wrap(~broadClass) +
   scale_y_log10() +
   xlab("") +
   ylab("Transcripts Per Million (TPM)") +

--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -151,13 +151,13 @@ cat("## TPM per biotype\n")
 cat("Different RNA-seq processing methods can preferentially capture a subset of the RNA species
 from the total RNA. For example, polyA selection should select for mostly coding genes and
 skip a large percentage of non-polyA non-coding RNA. Here we make boxplots of the TPM for
-the top 10 biotypes with the most genes assigned to them for each sample.")
+the top 12 biotypes with the most genes assigned to them for each sample.")
 keep_biotypes = rowData(bcb) %>%
   as.data.frame() %>%
   group_by(geneBiotype) %>%
   summarise(nBiotype=n()) %>%
   arrange(-nBiotype) %>%
-  top_n(10) %>%
+  top_n(12) %>%
   pull(geneBiotype) %>%
   droplevels()
 biotypetpm = tpm(bcb) %>%

--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -146,12 +146,13 @@ Generally, we expect similar count spreads for all genes between samples unless 
 plotCountsPerGene(bcb, normalized = "tmm")
 ```
 
-```{r biotype_plot, eval="geneBiotype" %in% colnames(rowData(bcb)), echo=FALSE, results='asis'}
+```{r biotype_plot, eval="geneBiotype" %in% colnames(rowData(bcb)), echo=FALSE}
 basejump::mdHeader("TPM per biotype", level=2)
-cat("Different RNA-seq processing methods can preferentially capture a subset of the RNA species
-from the total RNA. For example, polyA selection should select for mostly coding genes and
-skip a large percentage of non-polyA non-coding RNA. Here we make boxplots of the TPM for
-the top 12 biotypes with the most genes assigned to them for each sample.")
+knitr::asis_output("Different RNA-seq processing methods can preferentially capture a subset of
+  the RNA species from the total RNA. For example, polyA selection should select for mostly
+  coding genes and skip a large percentage of non-polyA non-coding RNA. Here we make boxplots
+  of the TPM for the top 12 biotypes with the most genes assigned to them for each sample.")
+
 keep_biotypes = rowData(bcb) %>%
   as.data.frame() %>%
   group_by(geneBiotype) %>%
@@ -179,10 +180,11 @@ ggplot(biotypetpm, aes(sample, tpm))+
         axis.title=element_text(size=10))
 ```
 
-```{r broadclass_plot, eval="broadClass" %in% colnames(rowData(bcb)), echo=FALSE, results='asis'}
+```{r broadclass_plot, eval="broadClass" %in% colnames(rowData(bcb)), echo=FALSE}
 basejump::mdHeader("TPM per broad biotype class", level=2)
-cat("The Ensembl biotype clasifications are too specific to plot them all-- here we have grouped
-the biotypes into broad classes and plot boxplots of the TPM for each sample.")
+knitr::asis_output("The Ensembl biotype clasifications are too specific to plot them all--
+  here we have grouped the biotypes into broad classes and plot boxplots of the TPM for each
+  sample.")
 biotypetpm = tpm(bcb) %>%
   as.data.frame() %>%
   tibble::rownames_to_column("gene") %>%

--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -146,6 +146,60 @@ Generally, we expect similar count spreads for all genes between samples unless 
 plotCountsPerGene(bcb, normalized = "tmm")
 ```
 
+```{r biotype_plot, eval="geneBiotype" %in% colnames(rowData(bcb)), echo=FALSE, results='asis'}
+cat("## TPM per biotype\n")
+cat("Different RNA-seq processing methods can preferentially capture a subset of the RNA species
+from the total RNA. For example, polyA selection should select for mostly coding genes and
+skip a large percentage of non-polyA non-coding RNA. Here we make boxplots of the TPM for
+the top 10 biotypes with the most genes assigned to them for each sample.")
+keep_biotypes = rowData(bcb) %>%
+  as.data.frame() %>%
+  group_by(geneBiotype) %>%
+  summarise(nBiotype=n()) %>%
+  arrange(-nBiotype) %>%
+  top_n(10) %>%
+  pull(geneBiotype) %>%
+  droplevels()
+biotypetpm = tpm(bcb) %>%
+  as.data.frame() %>%
+  tibble::rownames_to_column("gene") %>%
+  tidyr::gather(sample, tpm, -gene) %>%
+  dplyr::left_join(rowData(bcb) %>%
+                   as.data.frame(), by=c("gene"="geneID")) %>%
+  filter(geneBiotype %in% keep_biotypes)
+
+ggplot(biotypetpm, aes(sample, tpm))+
+  geom_violin() +
+  scale_y_log10() +
+  facet_wrap(~geneBiotype) +
+  xlab("") +
+  ylab("Transcripts Per Million (TPM)") +
+  theme(axis.text.x = element_text(angle = 90, hjust = 1),
+        axis.text=element_text(size=8),
+        axis.title=element_text(size=10))
+```
+
+```{r broadclass_plot, eval="broadClass" %in% colnames(rowData(bcb)), echo=FALSE, results='asis'}
+cat("## TPM per broad biotype class\n")
+cat("The Ensembl biotype clasifications are too specific to plot them all-- here we have grouped
+the biotypes into broad classes and plot boxplots of the TPM for each sample.")
+biotypetpm = tpm(bcb) %>%
+  as.data.frame() %>%
+  tibble::rownames_to_column("gene") %>%
+  tidyr::gather(sample, tpm, -gene) %>%
+  dplyr::left_join(rowData(bcb) %>%
+                   as.data.frame(), by=c("gene"="geneID"))
+
+ggplot(biotypetpm, aes(sample, tpm)) +
+  geom_boxplot() +
+  facet_wrap(~geneBiotype) +
+  scale_y_log10() +
+  xlab("") +
+  ylab("Transcripts Per Million (TPM)") +
+  theme(axis.text.x = element_text(angle = 90, hjust = 1),
+        axis.text=element_text(size=8),
+        axis.title=element_text(size=10))
+```
 
 ## Count density
 


### PR DESCRIPTION
Different capture methods expect different subsets of transcripts; here we use both the broad class and the top 12 most abundant geneBiotypes (in number of genes) to make TPM boxplots for each biotype/broad class.

This skips the appropriate step if the geneBiotype or broadClass data does not exist so it shouldn't break anything. In there is a demonstration regarding how to conditionally display markdown blocks as well.